### PR TITLE
Added support for Shopify Checkouts w/ no shipping (virtual products)

### DIFF
--- a/src/inject/shopify.js
+++ b/src/inject/shopify.js
@@ -16,6 +16,16 @@ chrome.extension.sendMessage({}, function (response) {
 				autofill('checkout_shipping_address_province', profile.state);
 				autofill('checkout_shipping_address_zip', profile.zipcode);
 				autofill('checkout_shipping_address_phone', profile.phoneNumber);
+				// billing below
+				autofill('checkout_billing_address_first_name', profile.firstName);
+				autofill('checkout_billing_address_last_name', profile.lastName);
+				autofill('checkout_billing_address_address1', profile.address);
+				autofill('checkout_billing_address_address2', profile.address2);
+				autofill('checkout_billing_address_city', profile.city);
+				autofill('checkout_billing_address_country', profile.country);
+				autofill('checkout_billing_address_province', profile.state);
+				autofill('checkout_billing_address_zip', profile.zipcode);
+				autofill('checkout_billing_address_phone', profile.phoneNumber);
 			}
 		}
 	});


### PR DESCRIPTION
If you are checking out a cart with no physical products in it, the first Shopify checkout page will replace the shipping information form with the billing information form. These are aesthetically the same, but have different HTML values. I have implemented a fix that allows autofill on these pages as well.